### PR TITLE
adding support for specifying IDs for the terminal.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ There are two ways to control the terminal. Calling API which is a interface of 
 <ng-terminal #term [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
 ```
 
+Non-Default Terminal ID
+
+If you want multiple terminal windows, you need to specify an ID for each.  There are two ways: give a static ID or use databinding to bind the ID to a variable on the implementing component.
+
+Static ID
+```html
+<ng-terminal #term id="someStaticID" [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
+```
+
+Data-bound ID
+```html
+<ng-terminal #term [id]="variableContainingId" [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
+```
+
+
 #### Underlying object
 
 You can control a instance of the xtermjs directly by getting a property of [underlying](https://github.com/qwefgh90/ng-terminal/blob/master/projects/ng-terminal/src/lib/ng-terminal.ts#L27). Check out API of the Terminal from the [API document](https://xtermjs.org/docs/)

--- a/projects/ng-terminal/README.md
+++ b/projects/ng-terminal/README.md
@@ -4,7 +4,7 @@
 
 NgTerminal is a web terminal that leverages xterm.js on Angular 7+. You can easily add it into your application by adding `<ng-terminal></ng-terminal>` into your component.
 
-NgTerminal provides some features including [xtermjs](https://xtermjs.org/). It provides to adjust dimensions by dragging and to fix the number of rows and cols. New usuful features to devlopers should be added continuously.
+NgTerminal provides some features including [xtermjs](https://xtermjs.org/). You can adjust dimensions of a terminal by dragging and to fix the number of rows and cols. New usuful features should be added continuously.
 
 ## Install
 
@@ -50,7 +50,6 @@ export class YourComponent implements AfterViewInit{
   @ViewChild('term', { static: true }) child: NgTerminal;
   
   ngAfterViewInit(){
-    this.invalidate();
     this.child.keyEventInput.subscribe(e => {
       console.log('keyboard event:' + e.domEvent.keyCode + ', ' + e.key);
 
@@ -75,9 +74,9 @@ export class YourComponent implements AfterViewInit{
 
 ## API
 
-There are two ways to control the web terminal. One is to call APIs of NgTerminal directly in your ts code. Another is to use properties or the event binding.
+There are two ways to control the terminal. Calling API which is a interface of NgTerminal provides is a direct way to control the terminal. You can bind a instance by using @ViewChild. Another way is to use input/output properties.
 
-#### NgTerminal
+#### NgTerminal (API)
 
 [NgTerminal](https://github.com/qwefgh90/ng-terminal/blob/master/projects/ng-terminal/src/lib/ng-terminal.ts) is a interface to provide public APIs you can call directly. You can get a object by using `@ViewChild` with a type of `NgTerminal`.
 
@@ -88,9 +87,9 @@ There are two ways to control the web terminal. One is to call APIs of NgTermina
   @ViewChild('term', { static: true }) child: NgTerminal; // for Angular 8
 ```
 
-#### NgTerminalComponent
+#### NgTerminalComponent (input/output properties)
 
-[NgTerminalComponent](https://github.com/qwefgh90/ng-terminal/blob/master/projects/ng-terminal/src/lib/ng-terminal.component.ts) is a implementation of `NgTerminal` and the component to draw the terminal.
+[NgTerminalComponent](https://github.com/qwefgh90/ng-terminal/blob/master/projects/ng-terminal/src/lib/ng-terminal.component.ts) is a component to implement `NgTerminal` and draw the terminal.
 
 ```html
 <ng-terminal #term [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
@@ -102,7 +101,7 @@ You can control a instance of the xtermjs directly by getting a property of [und
 
 #### Control sequences
 
-Control sequences is a programing interface to control terminal emulators. There are few implemented functions to return sequences including moving the cursor.
+Control sequences is a programing interface to control terminal emulators. There are functions to return control sequences in a class of `FunctionUsingCSI`.
 
 ```typescript
     import { FunctionsUsingCSI } from 'ng-terminal';
@@ -112,7 +111,6 @@ Control sequences is a programing interface to control terminal emulators. There
 ```
 
 You can also find a full set of sequences [here](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Controls-beginning-with-ESC). For example, you can break lines by passing `\x1b[1E` to `write()`. Try in the [sample page](https://qwefgh90.github.io/ng-terminal/)
-
 
 ## Contribution
 

--- a/projects/ng-terminal/README.md
+++ b/projects/ng-terminal/README.md
@@ -95,6 +95,21 @@ There are two ways to control the terminal. Calling API which is a interface of 
 <ng-terminal #term [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
 ```
 
+Non-Default Terminal ID
+
+If you want multiple terminal windows, you need to specify an ID for each.  There are two ways: give a static ID or use databinding to bind the ID to a variable on the implementing component.
+
+Static ID
+```html
+<ng-terminal #term id="someStaticID" [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
+```
+
+Data-bound ID
+```html
+<ng-terminal #term [id]="variableContainingId" [dataSource]="writeSubject" (keyEvent)="onKeyEvent($event)" [displayOption]="displayOptionBounded"></ng-terminal>
+```
+
+
 #### Underlying object
 
 You can control a instance of the xtermjs directly by getting a property of [underlying](https://github.com/qwefgh90/ng-terminal/blob/master/projects/ng-terminal/src/lib/ng-terminal.ts#L27). Check out API of the Terminal from the [API document](https://xtermjs.org/docs/)

--- a/projects/ng-terminal/src/lib/ng-terminal.component.html
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.html
@@ -1,5 +1,5 @@
 <global-style></global-style>
 
-<div id="terminal" class="terminal-outer" mwlResizable [ngStyle]="terminalStyle" [validateResize]="validatorFactory()" [enableGhostResize]="true" [resizeEdges]="isDraggableOnEdgeActivated ? {bottom: true, right: true} : {bottom: false, right: false}"
+<div [id]="terminalId" class="terminal-outer" mwlResizable [ngStyle]="terminalStyle" [validateResize]="validatorFactory()" [enableGhostResize]="true" [resizeEdges]="isDraggableOnEdgeActivated ? {bottom: true, right: true} : {bottom: false, right: false}"
 (resizeEnd)="onResizeEnd($event.rectangle.left, $event.rectangle.top, $event.rectangle.width, $event.rectangle.height)">
 </div>

--- a/projects/ng-terminal/src/lib/ng-terminal.component.html
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.html
@@ -1,5 +1,5 @@
 <global-style></global-style>
 
-<div [id]="terminalId" class="terminal-outer" mwlResizable [ngStyle]="terminalStyle" [validateResize]="validatorFactory()" [enableGhostResize]="true" [resizeEdges]="isDraggableOnEdgeActivated ? {bottom: true, right: true} : {bottom: false, right: false}"
+<div #terminal class="terminal-outer" mwlResizable [ngStyle]="terminalStyle" [validateResize]="validatorFactory()" [enableGhostResize]="true" [resizeEdges]="isDraggableOnEdgeActivated ? {bottom: true, right: true} : {bottom: false, right: false}"
 (resizeEnd)="onResizeEnd($event.rectangle.left, $event.rectangle.top, $event.rectangle.width, $event.rectangle.height)">
 </div>

--- a/projects/ng-terminal/src/lib/ng-terminal.component.spec.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.spec.ts
@@ -54,7 +54,7 @@ describe('NgTerminalComponent', () => {
       }
     });
 
-    const terminalEventConsumer = fixture.nativeElement.querySelector('#terminal').getElementsByTagName('textarea')[0];
+    const terminalEventConsumer = fixture.componentInstance.terminalDiv.nativeElement.getElementsByTagName('textarea')[0];
     arr.forEach((v) => {
       terminalEventConsumer.dispatchEvent(keydown(v));
     });
@@ -71,7 +71,7 @@ describe('NgTerminalComponent', () => {
       }
     });
 
-    const terminalEventConsumer = fixture.nativeElement.querySelector('#terminal').getElementsByTagName('textarea')[0];
+    const terminalEventConsumer = fixture.componentInstance.terminalDiv.nativeElement.getElementsByTagName('textarea')[0];
     arr.forEach((v) => {
       terminalEventConsumer.dispatchEvent(keydown(v));
     });
@@ -116,7 +116,7 @@ describe('DisplayOption', () => {
   });
 
   it("@Input('displayOption')", () => {
-    const term = fixture.nativeElement.querySelector('#terminal');
+    const term = fixture.componentInstance.terminalDiv.nativeElement;
     const beforeWidth = term.clientWidth;
     const beforeHeight = term.clientHeight;
     component._displayOption = {fixedGrid:{rows: 4, cols: 4}};
@@ -130,7 +130,7 @@ describe('DisplayOption', () => {
   })
 
   it('should decrease div size after changing fixedSize', () => {
-    const term = fixture.nativeElement.querySelector('#terminal');
+    const term = fixture.componentInstance.terminalDiv.nativeElement;
     const beforeWidth = term.clientWidth;
     const beforeHeight = term.clientHeight;
     component.setDisplayOption({fixedGrid:{rows: 4, cols: 4}});
@@ -144,7 +144,7 @@ describe('DisplayOption', () => {
   })
 
   it('should increase div size after changing fixedSize', () => {
-    const term = fixture.nativeElement.querySelector('#terminal');
+    const term = fixture.componentInstance.terminalDiv.nativeElement;
     component.setDisplayOption({fixedGrid:{rows: 4, cols: 4}});
     fixture.detectChanges();
     const beforeWidth = term.clientWidth;

--- a/projects/ng-terminal/src/lib/ng-terminal.component.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewChecked, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
+import { Component, OnInit, AfterViewChecked, Input, Output, EventEmitter, OnDestroy, AfterViewInit } from '@angular/core';
 import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 import { NgTerminal } from './ng-terminal';
@@ -11,7 +11,7 @@ import { ResizeEvent } from 'angular-resizable-element';
   templateUrl: './ng-terminal.component.html',
   styleUrls: ['./ng-terminal.component.css']
 })
-export class NgTerminalComponent implements OnInit, AfterViewChecked, NgTerminal, OnDestroy {
+export class NgTerminalComponent implements AfterViewInit, AfterViewChecked, NgTerminal, OnDestroy {
   private term: Terminal
   private keyInputSubject: Subject<string> = new Subject<string>();
   private keyEventSubject = new Subject<{key: string; domEvent: KeyboardEvent;}>();
@@ -25,6 +25,9 @@ export class NgTerminalComponent implements OnInit, AfterViewChecked, NgTerminal
   private dataSourceSubscription: Subscription;
   terminalStyle: object = {};
   
+  @Input('terminalId') 
+  terminalId = 'terminal';
+
   @Input('dataSource')
   set _dataSource(ds) {
     if(this.dataSourceSubscription != null){
@@ -108,10 +111,10 @@ export class NgTerminalComponent implements OnInit, AfterViewChecked, NgTerminal
   /**
    * It creates new terminal in #terminal.
    */
-  ngOnInit() {
+  ngAfterViewInit() {
     Terminal.applyAddon(fit);  // Apply the `fit` addon   
     this.term = new Terminal();
-    this.term.open(document.getElementById('terminal'));
+    this.term.open(document.getElementById(this.terminalId));
     this.observableSetup();
   }
 

--- a/projects/ng-terminal/src/lib/ng-terminal.component.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewChecked, Input, Output, EventEmitter, OnDestroy, AfterViewInit } from '@angular/core';
+import { Component, OnInit, AfterViewChecked, ViewChild, ElementRef, Input, Output, EventEmitter, OnDestroy, AfterViewInit } from '@angular/core';
 import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 import { NgTerminal } from './ng-terminal';
@@ -24,9 +24,6 @@ export class NgTerminalComponent implements AfterViewInit, AfterViewChecked, NgT
   private dataSource: Observable<string>;
   private dataSourceSubscription: Subscription;
   terminalStyle: object = {};
-  
-  @Input('terminalId') 
-  terminalId = 'terminal';
 
   @Input('dataSource')
   set _dataSource(ds) {
@@ -52,6 +49,9 @@ export class NgTerminalComponent implements AfterViewInit, AfterViewChecked, NgT
 
   @Output('keyEvent')
   keyEventEmitter  = new EventEmitter<{key: string; domEvent: KeyboardEvent;}>();
+
+  @ViewChild('terminal') 
+  terminalDiv: ElementRef;
 
   constructor() { }
 
@@ -114,7 +114,7 @@ export class NgTerminalComponent implements AfterViewInit, AfterViewChecked, NgT
   ngAfterViewInit() {
     Terminal.applyAddon(fit);  // Apply the `fit` addon   
     this.term = new Terminal();
-    this.term.open(document.getElementById(this.terminalId));
+    this.term.open(this.terminalDiv.nativeElement);
     this.observableSetup();
   }
 


### PR DESCRIPTION
Required to have multiple terminal components work at the same time.

Did three things:

1) created input class variable on ng-terminal-component.ts with a default of "terminal"
2) updated the xterm.open code to reference the class variable
3) moved xterm.open code to ngAfterViewInit instead of ngOnInit so the id will be properly injected into the component.