### PR TITLE
Enhance no DisplayOption error message

### DIFF
--- a/projects/ng-terminal/src/lib/ng-terminal.component.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.ts
@@ -183,7 +183,7 @@ export class NgTerminalComponent implements OnInit, AfterViewInit, AfterViewChec
       }
       this.displayOption = opt;
     } else
-      console.warn(`Am empty option is not allowed`);
+      console.warn(`A falsy option is not allowed`);
   }
 
   get keyInput(): Observable<string> {


### PR DESCRIPTION
- Fix typo
- Change empty by falsy: `{}` is an empty object and it is truthy.