### PR TITLE
fix: updated xterm xterm-addon-fit xterm-addon-web-links versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,9 @@
         "ngx-json-viewer": "^2.4.0",
         "rxjs": "~6.6.7",
         "tslib": "^2.0.0",
-        "xterm": "^4.19.0",
-        "xterm-addon-fit": "^0.5.0",
-        "xterm-addon-web-links": "^0.4.0",
+        "xterm": "^5.0.0",
+        "xterm-addon-fit": "^0.6.0",
+        "xterm-addon-web-links": "^0.7.0",
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
@@ -18012,22 +18012,24 @@
       }
     },
     "node_modules/xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
     },
     "node_modules/xterm-addon-fit": {
-      "version": "0.5.0",
-      "license": "MIT",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
       "peerDependencies": {
-        "xterm": "^4.0.0"
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/xterm-addon-web-links": {
-      "version": "0.4.0",
-      "license": "MIT",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-web-links/-/xterm-addon-web-links-0.7.0.tgz",
+      "integrity": "sha512-6PqoqzzPwaeSq22skzbvyboDvSnYk5teUYEoKBwMYvhbkwOQkemZccjWHT5FnNA8o1aInTc4PRYAl4jjPucCKA==",
       "peerDependencies": {
-        "xterm": "^4.0.0"
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/xxhashjs": {
@@ -20016,8 +20018,7 @@
       "version": "12.2.16",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.16.tgz",
       "integrity": "sha512-Y2wYX0ybpTYCuSXrG7+3FAtL4dSa7D1vMxymeJEmPTf5QcFTbllwcGQ82Q9lzTn3UDxvt6ZqAYfmWZHGp2GQ9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -20862,8 +20863,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "adjust-sourcemap-loader": {
       "version": "4.0.0",
@@ -20941,8 +20941,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.0",
@@ -20975,8 +20974,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "angular-resizable-element": {
       "version": "5.0.0",
@@ -21659,8 +21657,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -22582,8 +22579,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.0.1.tgz",
       "integrity": "sha512-VNCHL364lh++/ono+S3j9NlUK+d97KNkxI77NlqZU2W3xd2/qmyN61dsa47pTpb55zuU4G4lI7qFjAXZJH1OAQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -24222,8 +24218,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -25018,8 +25013,7 @@
     },
     "karma-jasmine-html-reporter": {
       "version": "1.5.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -25771,8 +25765,7 @@
       }
     },
     "ngx-json-viewer": {
-      "version": "2.4.0",
-      "requires": {}
+      "version": "2.4.0"
     },
     "nice-napi": {
       "version": "1.0.2",
@@ -27047,29 +27040,25 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.2.tgz",
       "integrity": "sha512-6VQ3pYTsJHEsN2Bic88Aa7J/Brn4Bv8j/rqaFQZkH+pcVkKYwxCIvoMQkykEW7fBjmofdTnQgcivt5CCBJhtrg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.2.tgz",
       "integrity": "sha512-LKY81YjUjc78p6rbXIsnppsaFo8XzCoMZkXVILJU//sK0DgPkPSpuq/cZvHss3EtdKvWNYgWzQL+wiJFtEET4g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.2.tgz",
       "integrity": "sha512-SxBsbTjlsKUvZLL+dMrdWauuNZU8TBq5IOL/DHa6jBUSXFEwmDqeXRfTIK/FQpPTa8MJMxEHjSV3UbiuyLARPQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.3.tgz",
       "integrity": "sha512-yRTXknIZA4k8Yo4FiF1xbsLj/VBxfXEWxJNIrtIy6HC9KQ4xJxcPtoaaskh6QptCGrrcGnhKsTsENTRPZOBu4g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -27538,8 +27527,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -27607,8 +27595,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.2.tgz",
       "integrity": "sha512-fEMhYXzO8My+gC009qDc/3bgnFP8Fv1Ic8uw4ec4YTlhIOw63tGPk1YFd7fk9bZUf1DAbkhiL/QPWs9JLqdF2g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.2",
@@ -29756,8 +29743,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
       "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylehacks": {
       "version": "5.0.2",
@@ -30092,8 +30078,7 @@
     },
     "tsickle": {
       "version": "0.39.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tslib": {
       "version": "2.3.1"
@@ -31220,8 +31205,7 @@
     },
     "ws": {
       "version": "8.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",
@@ -31242,17 +31226,19 @@
       "dev": true
     },
     "xterm": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
-      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
     },
     "xterm-addon-fit": {
-      "version": "0.5.0",
-      "requires": {}
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg=="
     },
     "xterm-addon-web-links": {
-      "version": "0.4.0",
-      "requires": {}
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-web-links/-/xterm-addon-web-links-0.7.0.tgz",
+      "integrity": "sha512-6PqoqzzPwaeSq22skzbvyboDvSnYk5teUYEoKBwMYvhbkwOQkemZccjWHT5FnNA8o1aInTc4PRYAl4jjPucCKA=="
     },
     "xxhashjs": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "ngx-json-viewer": "^2.4.0",
     "rxjs": "~6.6.7",
     "tslib": "^2.0.0",
-    "xterm": "^4.19.0",
-    "xterm-addon-fit": "^0.5.0",
-    "xterm-addon-web-links": "^0.4.0",
+    "xterm": "^5.0.0",
+    "xterm-addon-fit": "^0.6.0",
+    "xterm-addon-web-links": "^0.7.0",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/projects/demo-v10/src/app/example.component.ts
+++ b/projects/demo-v10/src/app/example.component.ts
@@ -128,7 +128,7 @@ export class ExampleComponent implements OnInit, AfterViewInit {
   baseTheme = {
     foreground: '#F8F8F8',
     background: '#2D2E2C',
-    selection: '#5DA5D533',
+    selectionBackground: '#5DA5D533',
     black: '#1E1E1D',
     brightBlack: '#262625',
     red: '#CE5C5C',

--- a/projects/ng-terminal/package.json
+++ b/projects/ng-terminal/package.json
@@ -40,7 +40,7 @@
     "angular-resizable-element": "^5.0.0",
     "@juggle/resize-observer": "^3.4.0",
     "tslib": "^2.0.0",
-    "xterm-addon-fit": "^0.5.0",
-    "xterm": "^4.19.0"
+    "xterm-addon-fit": "^0.6.0",
+    "xterm": "^5.0.0"
   }
 }

--- a/projects/ng-terminal/src/lib/global-style/xterm.css
+++ b/projects/ng-terminal/src/lib/global-style/xterm.css
@@ -163,9 +163,11 @@
     opacity: 0.5;
 }
 
-.xterm-underline {
-    text-decoration: underline;
-}
+.xterm-underline-1 { text-decoration: underline; }
+.xterm-underline-2 { text-decoration: double underline; }
+.xterm-underline-3 { text-decoration: wavy underline; }
+.xterm-underline-4 { text-decoration: dotted underline; }
+.xterm-underline-5 { text-decoration: dashed underline; }
 
 .xterm-strikethrough {
     text-decoration: line-through;

--- a/projects/ng-terminal/src/lib/ng-terminal.component.material.spec.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.material.spec.ts
@@ -102,6 +102,8 @@ describe('NgTerminalComponent with MaterialTab', () => {
     mattabComponent.tabGroup.selectedIndex = 1;
     mattabFixture.detectChanges();
     tick(1000);
+    mattabComponent.terminal.setRows(10);
+    mattabComponent.terminal.setCols(10);
     mattabFixture.detectChanges();
 
     let mattabEl = mattabFixture.nativeElement as HTMLElement;

--- a/projects/ng-terminal/src/lib/ng-terminal.component.ts
+++ b/projects/ng-terminal/src/lib/ng-terminal.component.ts
@@ -296,7 +296,9 @@ export class NgTerminalComponent implements OnInit, OnChanges, AfterViewInit, Ng
    */
   ngAfterViewInit() {
     this.fitAddon = new FitAddon();
-    this.term = new Terminal();
+    this.term = new Terminal({
+      allowProposedApi: true
+    });
     this.term.open(this.terminalOuter.nativeElement);
     this.term.loadAddon(this.fitAddon);
     this.observableSetup();


### PR DESCRIPTION
Updated xterm(5.0.0), xterm-addon-fit(0.6.0) and xterm-addon-web-links(0.7.0) packages to latest versions.

**Breaking Changes** - 
Followed [https://openbase.com/js/xterm/versions](https://openbase.com/js/xterm/versions) to fix the code breakage.
1. **ng-terminal.component.ts** file - ![image](https://user-images.githubusercontent.com/7556759/205100216-fa4f728b-c935-47f5-895e-bab2f36e6ede.png)
2. **example.component.ts file** - 
![image](https://user-images.githubusercontent.com/7556759/205101642-98243394-ec8a-4111-a425-60365e6d1de1.png)


